### PR TITLE
yts.to

### DIFF
--- a/users.html
+++ b/users.html
@@ -12,7 +12,6 @@ layout: default
   </ul>
 </li>
 <li><a href="https://meta.miraheze.org/">Miraheze</a> uses gdnsd, with the <a href="https://github.com/Miraheze/dns">config on Github</a></li>
-<li><a href="http://yts.to/">YTS</a> uses gdnsd</li>
 <li><a href="http://www.openstreetmap.org/">OpenStreetMap</a> is using gdnsd, and their <a href="http://git.openstreetmap.org/chef.git/tree/HEAD:/cookbooks/geodns">Chef cookbook</a> for gdnsd is available!</li>
 <li><a href="https://www.scaleengine.com/">Scale Engine</a> is using gdnsd for their Video CDN: <a href="https://www.scaleengine.com/read/422/Geographically-Aware-DNS-using-gdnsd/">Blog Post</a></li>
 <li><a href="http://www.squeezenetwork.com/">Logitech</a> - gdnsd does the DNS for Logitech's SqueezeNetwork service</li>


### PR DESCRIPTION
yts.to was shutdown for copyright infringement.
http://heavy.com/tech/2015/10/yts-shutdown-shut-down-gone-what-happened-to-yify-alternative-issues-error-movies-sued/
