### PR TITLE
res.html: Add missing quote

### DIFF
--- a/res.html
+++ b/res.html
@@ -7,4 +7,4 @@ layout: default
 <p>Release Tarballs @Github: <a href="https://github.com/gdnsd/gdnsd/releases/">https://github.com/gdnsd/gdnsd/releases/</a></p>
 <p>Bugs/Issues @Github: <a href="https://github.com/gdnsd/gdnsd/issues">https://github.com/gdnsd/gdnsd/issues</a></p>
 <p>Wikified docs @Github: <a href="https://github.com/gdnsd/gdnsd/wiki">https://github.com/gdnsd/gdnsd/wiki</a></p>
-<p>Codeberg (4.x development): <a href=https://codeberg.org/gdnsd/gdnsd">https://codeberg.org/gdnsd/gdnsd</a></p>
+<p>Codeberg (4.x development): <a href="https://codeberg.org/gdnsd/gdnsd">https://codeberg.org/gdnsd/gdnsd</a></p>


### PR DESCRIPTION
The missing href quote causes the URL to inappropriately have a " at the end of the URL, resulting in a 404.